### PR TITLE
ensures correct timezone

### DIFF
--- a/src/App/Services/Data/Computors/Date.php
+++ b/src/App/Services/Data/Computors/Date.php
@@ -23,6 +23,7 @@ class Date implements ComputesArrayColumns
         foreach (self::$columns as $column) {
             if ($row[$column->get('name')] !== null) {
                 $row[$column->get('name')] = Carbon::parse($row[$column->get('name')])
+                    ->setTimezone(Config::get('app.timezone'))
                     ->format(self::format($column));
             }
         }


### PR DESCRIPTION
similar to the DateTime table computor. 

If we don't enforce the timezone, after parsing, the timezone will be Zulu; 

When the app is on a different timezone, the resulted, formatted date will be different than the persisted value.