### PR TITLE
fixes count for groupBy #237

### DIFF
--- a/src/Services/Data/Builders/Meta.php
+++ b/src/Services/Data/Builders/Meta.php
@@ -59,11 +59,9 @@ class Meta
         ];
     }
 
-    public function count($filtered = false): int
+    public function count(): int
     {
-        return $filtered
-            ? $this->query->count()
-            : $this->query->getQuery()->getCountForPagination();
+        return $this->query->getQuery()->getCountForPagination();
     }
 
     private function setCount(): self
@@ -98,7 +96,7 @@ class Meta
     private function countFiltered(): self
     {
         if ($this->filters && $this->fullRecordInfo) {
-            $this->filtered = $this->count(true);
+            $this->filtered = $this->count();
         }
 
         return $this;


### PR DESCRIPTION
this commit reverts [#2709e93](https://github.com/laravel-enso/tables/commit/2709e931c9afa324ee78c6bde61e8083098c1ffc), I talked with @vmcvlad  about [#2709e93](https://github.com/laravel-enso/tables/commit/2709e931c9afa324ee78c6bde61e8083098c1ffc)  too, we didn't understand why `$filtered` was  used at that moment.
`$this->query->count()` breaks groupBy queries